### PR TITLE
Unified truefoundry role

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Truefoundry AWS Control Plane Module
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mlfoundry_oidc_iam"></a> [mlfoundry\_oidc\_iam](#module\_mlfoundry\_oidc\_iam) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.27.0 |
-| <a name="module_svcfoundry_oidc_iam"></a> [svcfoundry\_oidc\_iam](#module\_svcfoundry\_oidc\_iam) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.27.0 |
 | <a name="module_truefoundry_bucket"></a> [truefoundry\_bucket](#module\_truefoundry\_bucket) | terraform-aws-modules/s3-bucket/aws | 3.14.0 |
+| <a name="module_truefoundry_oidc_iam"></a> [truefoundry\_oidc\_iam](#module\_truefoundry\_oidc\_iam) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.27.0 |
 
 ## Resources
 
@@ -86,8 +85,6 @@ Truefoundry AWS Control Plane Module
 
 | Name | Description |
 |------|-------------|
-| <a name="output_mlfoundry_iam_role_arn"></a> [mlfoundry\_iam\_role\_arn](#output\_mlfoundry\_iam\_role\_arn) | n/a |
-| <a name="output_svcfoundry_iam_role_arn"></a> [svcfoundry\_iam\_role\_arn](#output\_svcfoundry\_iam\_role\_arn) | n/a |
 | <a name="output_truefoundry_bucket_id"></a> [truefoundry\_bucket\_id](#output\_truefoundry\_bucket\_id) | n/a |
 | <a name="output_truefoundry_db_address"></a> [truefoundry\_db\_address](#output\_truefoundry\_db\_address) | n/a |
 | <a name="output_truefoundry_db_database_name"></a> [truefoundry\_db\_database\_name](#output\_truefoundry\_db\_database\_name) | n/a |
@@ -97,4 +94,5 @@ Truefoundry AWS Control Plane Module
 | <a name="output_truefoundry_db_password"></a> [truefoundry\_db\_password](#output\_truefoundry\_db\_password) | n/a |
 | <a name="output_truefoundry_db_port"></a> [truefoundry\_db\_port](#output\_truefoundry\_db\_port) | n/a |
 | <a name="output_truefoundry_db_username"></a> [truefoundry\_db\_username](#output\_truefoundry\_db\_username) | n/a |
+| <a name="output_truefoundry_iam_role_arn"></a> [truefoundry\_iam\_role\_arn](#output\_truefoundry\_iam\_role\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 Truefoundry AWS Control Plane Module
 
 <!-- BEGIN_TF_DOCS -->
-## Upgrade 
-### From 0.3.2 - 0.3.3
-- `mlfoundry_oidc_iam` and `svcfoundry_oidc_iam` replaced with a single role `truefoundry_oidc_iam`
-- outputs `mlfoundry_iam_role_arn` and `svcfoundry_iam_role_arn` replaced with `truefoundry_iam_role_arn`
-
 ## Requirements
 
 | Name | Version |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 Truefoundry AWS Control Plane Module
 
 <!-- BEGIN_TF_DOCS -->
+## Upgrade 
+### From 0.3.2 - 0.3.3
+- `mlfoundry_oidc_iam` and `svcfoundry_oidc_iam` replaced with a single role `truefoundry_oidc_iam`
+- outputs `mlfoundry_iam_role_arn` and `svcfoundry_iam_role_arn` replaced with `truefoundry_iam_role_arn`
+
 ## Requirements
 
 | Name | Version |

--- a/iam-sa.tf
+++ b/iam-sa.tf
@@ -1,36 +1,19 @@
 # From https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/irsa/irsa.tf
 
-module "mlfoundry_oidc_iam" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "5.27.0"
-
-  create_role  = true
-  role_name    = "${var.cluster_name}-mlfoundry-deps"
-  provider_url = replace(var.cluster_oidc_issuer_url, "https://", "")
-  oidc_fully_qualified_subjects = [
-    "system:serviceaccount:${var.mlfoundry_k8s_namespace}:${var.mlfoundry_k8s_service_account}"
-  ]
-
-  role_policy_arns = [
-    aws_iam_policy.truefoundry_bucket_policy.arn,
-    aws_iam_policy.truefoundry_assume_role_all.arn,
-  ]
-  tags = local.tags
-}
-
 data "aws_iam_policy" "servicefoundry_ecr_policy" {
   name = "AmazonEC2ContainerRegistryFullAccess"
 }
 
-module "svcfoundry_oidc_iam" {
+module "truefoundry_oidc_iam" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "5.27.0"
 
   create_role  = true
-  role_name    = "${var.cluster_name}-svcfoundry-deps"
+  role_name    = "${var.cluster_name}-truefoundry-deps"
   provider_url = replace(var.cluster_oidc_issuer_url, "https://", "")
   oidc_fully_qualified_subjects = [
-    "system:serviceaccount:${var.svcfoundry_k8s_namespace}:${var.svcfoundry_k8s_service_account}"
+    "system:serviceaccount:${var.svcfoundry_k8s_namespace}:${var.svcfoundry_k8s_service_account}",
+    "system:serviceaccount:${var.mlfoundry_k8s_namespace}:${var.mlfoundry_k8s_service_account}"
   ]
 
   role_policy_arns = [

--- a/output.tf
+++ b/output.tf
@@ -35,14 +35,6 @@ output "truefoundry_bucket_id" {
   value = module.truefoundry_bucket.s3_bucket_id
 }
 
-# output "mlfoundry_iam_role_arn" {
-#   value = module.mlfoundry_oidc_iam.iam_role_arn
-# }
-
-# output "svcfoundry_iam_role_arn" {
-#   value = module.svcfoundry_oidc_iam.iam_role_arn
-# }
-
 output "truefoundry_iam_role_arn" {
   value = module.truefoundry_oidc_iam.iam_role_arn
 }

--- a/output.tf
+++ b/output.tf
@@ -35,10 +35,14 @@ output "truefoundry_bucket_id" {
   value = module.truefoundry_bucket.s3_bucket_id
 }
 
-output "mlfoundry_iam_role_arn" {
-  value = module.mlfoundry_oidc_iam.iam_role_arn
-}
+# output "mlfoundry_iam_role_arn" {
+#   value = module.mlfoundry_oidc_iam.iam_role_arn
+# }
 
-output "svcfoundry_iam_role_arn" {
-  value = module.svcfoundry_oidc_iam.iam_role_arn
+# output "svcfoundry_iam_role_arn" {
+#   value = module.svcfoundry_oidc_iam.iam_role_arn
+# }
+
+output "truefoundry_iam_role_arn" {
+  value = module.truefoundry_oidc_iam.iam_role_arn
 }


### PR DESCRIPTION
1. Removing `mlfoundry` and `svcfoundry` IAM role into a single truefoundry IAM role