### PR TITLE
Moving to RDS version 17

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -21,7 +21,5 @@ locals {
 
   postgres_parameter_group_family = strcontains(var.truefoundry_db_engine_version, "17") ? "postgres17" : "postgres13"
 
-
-
   truefoundry_iam_role_policy_prefix = var.truefoundry_iam_role_policy_prefix_override_enabled ? "${var.truefoundry_iam_role_policy_prefix_override_name}-${local.svcfoundry_unique_name}" : local.svcfoundry_unique_name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -19,5 +19,9 @@ locals {
     var.tags
   )
 
+  postgres_parameter_group_family = strcontains(var.truefoundry_db_engine_version, "17") ? "postgres17" : "postgres13"
+
+
+
   truefoundry_iam_role_policy_prefix = var.truefoundry_iam_role_policy_prefix_override_enabled ? "${var.truefoundry_iam_role_policy_prefix_override_name}-${local.svcfoundry_unique_name}" : local.svcfoundry_unique_name
 }

--- a/rds.tf
+++ b/rds.tf
@@ -82,16 +82,27 @@ resource "aws_db_instance" "truefoundry_db" {
   deletion_protection                   = var.truefoundry_db_deletion_protection
   iam_database_authentication_enabled   = var.iam_database_authentication_enabled
   apply_immediately                     = true
+  allow_major_version_upgrade           = var.truefoundry_db_allow_major_version_upgrade
   storage_encrypted                     = var.truefoundry_db_storage_encrypted
   enabled_cloudwatch_logs_exports       = var.truefoundry_cloudwatch_log_exports
   storage_type                          = var.truefoundry_db_storage_type
   iops                                  = var.truefoundry_db_storage_iops == 0 ? null : var.truefoundry_db_storage_iops
-
+  parameter_group_name                  = var.truefoundry_db_postgres_parameter_group_override_enabled ? var.truefoundry_db_postgres_parameter_group_override_name : aws_db_parameter_group.truefoundry_db_parameter_group.name
   lifecycle {
     ignore_changes = [
       identifier,
       final_snapshot_identifier
     ]
+  }
+}
+
+resource "aws_db_parameter_group" "truefoundry_db_parameter_group" {
+  name   = "${local.truefoundry_db_unique_name}-rds-pg"
+  family = local.postgres_parameter_group_family
+
+  parameter {
+    name  = "rds.force_ssl"
+    value = "0"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "truefoundry_db_storage_encrypted" {
 }
 
 variable "truefoundry_db_engine_version" {
-  default     = "13.20"
+  default     = "17.5"
   type        = string
   description = "Truefoundry DB Postgres version"
 }
@@ -188,6 +188,12 @@ variable "truefoundry_db_enable_insights" {
   default     = false
 }
 
+variable "truefoundry_db_allow_major_version_upgrade" {
+  description = "Allow major version upgrade. This should be set to true if you want to upgrade the db version"
+  type        = bool
+  default     = false
+}
+
 variable "truefoundry_cloudwatch_log_exports" {
   description = "Set of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported"
   type        = list(string)
@@ -198,6 +204,18 @@ variable "truefoundry_db_multiple_az" {
   description = "Enable Multi-az (standby) instances for RDS instances"
   type        = bool
   default     = false
+}
+
+variable "truefoundry_db_postgres_parameter_group_override_enabled" {
+  description = "Enable override for postgres parameter group. You must pass truefoundry_db_postgres_parameter_group_override_name"
+  type        = bool
+  default     = false
+}
+
+variable "truefoundry_db_postgres_parameter_group_override_name" {
+  description = "Override name for postgres parameter group. truefoundry_db_postgres_parameter_group_override_enabled must be set true"
+  type        = string
+  default     = ""
 }
 
 variable "iam_database_authentication_enabled" {


### PR DESCRIPTION
1. Moving to RDS v17 by default
2. `truefoundry_db_allow_major_version_upgrade` should be `true` to upgrade.
3. Added support for passing custom db parameter group
4. DB upgrade will have noted downtime.