### PR TITLE
Modify OIDC provider URL handling in iam-sa.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Truefoundry AWS Control Plane Module
 | <a name="input_master_user_password_rotation_duration"></a> [master\_user\_password\_rotation\_duration](#input\_master\_user\_password\_rotation\_duration) | Master user password rotation duration | `string` | `"3h"` | no |
 | <a name="input_mlfoundry_k8s_namespace"></a> [mlfoundry\_k8s\_namespace](#input\_mlfoundry\_k8s\_namespace) | The k8s mlfoundry namespace | `string` | `"truefoundry"` | no |
 | <a name="input_mlfoundry_k8s_service_account"></a> [mlfoundry\_k8s\_service\_account](#input\_mlfoundry\_k8s\_service\_account) | The k8s mlfoundry service account name | `string` | `"mlfoundry-server"` | no |
+| <a name="input_secondary_cluster_oidc_issuer_url"></a> [secondary\_cluster\_oidc\_issuer\_url](#input\_secondary\_cluster\_oidc\_issuer\_url) | The oidc url of the secondary cluster | `string` | `null` | no |
 | <a name="input_svcfoundry_k8s_namespace"></a> [svcfoundry\_k8s\_namespace](#input\_svcfoundry\_k8s\_namespace) | The k8s svcfoundry namespace | `string` | `"truefoundry"` | no |
 | <a name="input_svcfoundry_k8s_service_account"></a> [svcfoundry\_k8s\_service\_account](#input\_svcfoundry\_k8s\_service\_account) | The k8s svcfoundry service account name | `string` | `"servicefoundry-server"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | AWS Tags common to all the resources created | `map(string)` | `{}` | no |

--- a/iam-sa.tf
+++ b/iam-sa.tf
@@ -7,7 +7,7 @@ module "truefoundry_oidc_iam" {
 
   create_role  = true
   role_name    = var.truefoundry_iam_role_enable_override ? var.truefoundry_iam_role_override_name : "${var.cluster_name}-truefoundry-deps"
-  provider_url = replace(var.cluster_oidc_issuer_url, "https://", "")
+  provider_urls = concat([replace(var.cluster_oidc_issuer_url, "https://", ""), var.secondary_cluster_oidc_issuer_url != null ? replace(var.secondary_cluster_oidc_issuer_url, "https://", "") : null])
   oidc_fully_qualified_subjects = concat([
     "system:serviceaccount:${var.svcfoundry_k8s_namespace}:${var.svcfoundry_k8s_service_account}",
     "system:serviceaccount:${var.mlfoundry_k8s_namespace}:${var.mlfoundry_k8s_service_account}",

--- a/iam-sa.tf
+++ b/iam-sa.tf
@@ -5,8 +5,8 @@ module "truefoundry_oidc_iam" {
   count   = var.truefoundry_iam_role_enabled ? 1 : 0
   version = "5.39.1"
 
-  create_role  = true
-  role_name    = var.truefoundry_iam_role_enable_override ? var.truefoundry_iam_role_override_name : "${var.cluster_name}-truefoundry-deps"
+  create_role   = true
+  role_name     = var.truefoundry_iam_role_enable_override ? var.truefoundry_iam_role_override_name : "${var.cluster_name}-truefoundry-deps"
   provider_urls = compact([replace(var.cluster_oidc_issuer_url, "https://", ""), var.secondary_cluster_oidc_issuer_url != null ? replace(var.secondary_cluster_oidc_issuer_url, "https://", "") : null])
   oidc_fully_qualified_subjects = concat([
     "system:serviceaccount:${var.svcfoundry_k8s_namespace}:${var.svcfoundry_k8s_service_account}",

--- a/iam-sa.tf
+++ b/iam-sa.tf
@@ -7,7 +7,7 @@ module "truefoundry_oidc_iam" {
 
   create_role  = true
   role_name    = var.truefoundry_iam_role_enable_override ? var.truefoundry_iam_role_override_name : "${var.cluster_name}-truefoundry-deps"
-  provider_urls = concat([replace(var.cluster_oidc_issuer_url, "https://", ""), var.secondary_cluster_oidc_issuer_url != null ? replace(var.secondary_cluster_oidc_issuer_url, "https://", "") : null])
+  provider_urls = compact([replace(var.cluster_oidc_issuer_url, "https://", ""), var.secondary_cluster_oidc_issuer_url != null ? replace(var.secondary_cluster_oidc_issuer_url, "https://", "") : null])
   oidc_fully_qualified_subjects = concat([
     "system:serviceaccount:${var.svcfoundry_k8s_namespace}:${var.svcfoundry_k8s_service_account}",
     "system:serviceaccount:${var.mlfoundry_k8s_namespace}:${var.mlfoundry_k8s_service_account}",

--- a/variables.tf
+++ b/variables.tf
@@ -566,3 +566,14 @@ variable "truefoundry_iam_role_policy_prefix_override_name" {
   type        = string
   description = "Truefoundry IAM role policy prefix. This is the prefix for the policies that will be attached to the truefoundry IAM role"
 }
+
+
+##################################################################################
+## Secondary cluster
+##################################################################################
+
+variable "secondary_cluster_oidc_issuer_url" {
+  default     = null
+  type        = string
+  description = "The oidc url of the secondary cluster"
+}


### PR DESCRIPTION
Updated provider_url to provider_urls for handling multiple OIDC issuer URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes IAM OIDC trust for the shared Truefoundry role; misconfigured secondary URLs could allow unintended cluster principals to assume the role, though default null preserves prior single-cluster behavior.
> 
> **Overview**
> Adds optional **secondary cluster** OIDC support so the Truefoundry IRSA role can be assumed from workloads on a second EKS cluster, not only the primary.
> 
> The `truefoundry_oidc_iam` module now passes **`provider_urls`** (plural) instead of a single `provider_url`, built with `compact()` from the existing primary `cluster_oidc_issuer_url` plus the new optional `secondary_cluster_oidc_issuer_url` (both with `https://` stripped). When the secondary input is omitted or `null`, behavior matches a single-cluster setup.
> 
> A new module input **`secondary_cluster_oidc_issuer_url`** (default `null`) and README entry document the option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e20c825e9365f5833912d423131df8d23cdaecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->